### PR TITLE
Pagingnumber

### DIFF
--- a/src/main/java/com/mysite/sbb/question/QuestionService.java
+++ b/src/main/java/com/mysite/sbb/question/QuestionService.java
@@ -6,9 +6,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,7 +29,9 @@ public class QuestionService {
     }
 
     public Page<Question> getList(int page){
-        Pageable pageable = PageRequest.of(page,10);
+        List<Sort.Order> sort = new ArrayList<>();
+        sort.add(Sort.Order.desc("createDate"));
+        Pageable pageable = PageRequest.of(page,10,Sort.by(sort));
         return questionRepository.findAll(pageable);
     }
 

--- a/src/main/resources/templates/question_list.html
+++ b/src/main/resources/templates/question_list.html
@@ -10,7 +10,7 @@
         </thead>
         <tbody>
         <tr th:each="question, loop : ${paging}">
-            <td th:text="${loop.count}"></td>
+            <td th:text="${paging.getTotalElements - (paging.number * paging.size) - loop.index}"></td>
             <td>
                 <a th:href="@{|/question/detail/${question.id}|}" th:text="${question.subject}"></a>
             </td>

--- a/src/main/resources/templates/question_list.html
+++ b/src/main/resources/templates/question_list.html
@@ -28,6 +28,7 @@
                 </a>
             </li>
             <li th:each="page: ${#numbers.sequence(0, paging.totalPages-1)}"
+                th:if="${page >= paging.number-5 and page <= paging.number+5}"
                 th:classappend="${page == paging.number} ? 'active'"
                 class="page-item">
                 <a th:text="${page}" class="page-link" th:href="@{|?page=${page}|}"></a>

--- a/src/main/resources/templates/question_list.html
+++ b/src/main/resources/templates/question_list.html
@@ -13,6 +13,9 @@
             <td th:text="${paging.getTotalElements - (paging.number * paging.size) - loop.index}"></td>
             <td>
                 <a th:href="@{|/question/detail/${question.id}|}" th:text="${question.subject}"></a>
+                <span class="text-danger small ms-2"
+                      th:if="${#lists.size(question.answerList)>0}"
+                      th:text="${#lists.size(question.answerList)}"></span>
             </td>
             <td th:text="${#temporals.format(question.createDate, 'yyyy-MM-dd HH:mm')}"></td>
         </tr>


### PR DESCRIPTION
- 정렬을 통해서 최신 시간순으로 게시물 정리
- 각 게시물 번호에 맞게 번호 공식 추가
- 답변이 몇개 적혀있는지 알기위해서 각 질문에 답변개수가 보이게 추가
- N : 1 관계인 answer과 question 이 나중에 N+1 이슈가 발생하지 않게 answer 쪽 question 에 lazy Loading으로 변경